### PR TITLE
ci: add cooldown settings to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: monthly
     groups:
       ci-dependencies:
-        dependency-type: 'production'
+        dependency-type: production
     commit-message:
       prefix: deps
+    cooldown:
+      default-days: 10


### PR DESCRIPTION
This PR adds [cooldown settings](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) to the dependabot configuration for all package ecosystems.

## What this does:

- Allows dependabot to delay including dependencies for a configurable number of days.

## Benefits:

- The community finds supply chain vulnerabilities and bugs before they are included in a pull request.
